### PR TITLE
Only update drift when having valid values.

### DIFF
--- a/implementations/prometheus/stats.go
+++ b/implementations/prometheus/stats.go
@@ -266,10 +266,14 @@ func (s *PrometheusStats) UpdateNetwork(stats types.NetworkStats) {
 	s.NetworkRetries5XX.Add(float64(stats.Total5XX()))
 	s.NetworkSentDuration.Observe(stats.SendDuration.Seconds())
 	s.RemoteStorageDuration.Observe(stats.SendDuration.Seconds())
-	// The newest timestamp is no always sent.
+	// The newest timestamp is not always sent.
 	if stats.NewestTimestampSeconds != 0 {
 		s.networkOut.Store(stats.NewestTimestampSeconds)
-		s.TimestampDriftSeconds.Set(float64(s.serializerIn.Load() - s.networkOut.Load()))
+		// We always want to ensure that we have real values, else there is a window where this can be
+		// timestamp - 0 which gives a result in the years.
+		if s.serializerIn.Load() != 0 && s.networkOut.Load() != 0 {
+			s.TimestampDriftSeconds.Set(float64(s.serializerIn.Load() - s.networkOut.Load()))
+		}
 		s.RemoteStorageOutTimestamp.Set(float64(stats.NewestTimestampSeconds))
 		s.NetworkNewestOutTimeStampSeconds.Set(float64(stats.NewestTimestampSeconds))
 	}
@@ -296,7 +300,11 @@ func (s *PrometheusStats) UpdateSerializer(stats types.SerializerStats) {
 	s.SerializerErrors.Add(float64(stats.Errors))
 	if stats.NewestTimestampSeconds != 0 {
 		s.serializerIn.Store(stats.NewestTimestampSeconds)
-		s.TimestampDriftSeconds.Set(float64(s.serializerIn.Load() - s.networkOut.Load()))
+		// We always want to ensure that we have real values, else there is a window where this can be
+		// timestamp - 0 which gives a result in the years.
+		if s.serializerIn.Load() != 0 && s.networkOut.Load() != 0 {
+			s.TimestampDriftSeconds.Set(float64(s.serializerIn.Load() - s.networkOut.Load()))
+		}
 		s.SerializerNewestInTimeStampSeconds.Set(float64(stats.NewestTimestampSeconds))
 		s.RemoteStorageInTimestamp.Set(float64(stats.NewestTimestampSeconds))
 	}

--- a/implementations/prometheus/stats_test.go
+++ b/implementations/prometheus/stats_test.go
@@ -1,0 +1,37 @@
+package prometheus
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+
+	"github.com/grafana/walqueue/types"
+	prom "github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestDriftSerializer(t *testing.T) {
+	ps := NewStats("test", "test", prom.NewRegistry())
+	ps.UpdateSerializer(types.SerializerStats{
+		SeriesStored:           1,
+		MetadataStored:         1,
+		Errors:                 0,
+		NewestTimestampSeconds: time.Now().Unix(),
+		TTLDropped:             0,
+	})
+	dt := &dto.Metric{}
+	err := ps.TimestampDriftSeconds.Write(dt)
+	require.NoError(t, err)
+	require.Equal(t, float64(0), dt.Gauge.GetValue())
+}
+
+func TestDriftNetwork(t *testing.T) {
+	ps := NewStats("test", "test", prom.NewRegistry())
+	ps.UpdateNetwork(types.NetworkStats{
+		NewestTimestampSeconds: time.Now().Unix(),
+	})
+	dt := &dto.Metric{}
+	err := ps.TimestampDriftSeconds.Write(dt)
+	require.NoError(t, err)
+	require.Equal(t, float64(0), dt.Gauge.GetValue())
+}


### PR DESCRIPTION
Add check to ensure the in and out have valid values before setting the drift. On startup of new loops this can lead to really odd values in the years.