### PR TITLE
Bug: Context was not being checked in retry loop

### DIFF
--- a/network/write.go
+++ b/network/write.go
@@ -65,8 +65,12 @@ func (l *write) trySend(buf []byte, ctx context.Context) {
 			level.Debug(l.log).Log("msg", "max retry attempts reached", "attempts", attempts)
 			return
 		}
-		// Sleep between attempts.
-		time.Sleep(result.retryAfter)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(result.retryAfter):
+			continue
+		}
 	}
 }
 


### PR DESCRIPTION
Need to check the context while in the retry loop to ensure it hasnt been closed, else the http.client will immediately fail and if there is no max tries it will loop forever.