### PR TITLE
Switch to batching the metrics to reduce locking pressure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /.idea
+.aider*

--- a/implementations/prometheus/queue.go
+++ b/implementations/prometheus/queue.go
@@ -114,6 +114,8 @@ func (q *queue) Start(ctx context.Context) error {
 	q.queue.Start(ctx)
 	err := q.serializer.Start(ctx)
 	if err != nil {
+		q.network.Stop()
+		q.queue.Stop()
 		return err
 	}
 	go q.run(ctx)

--- a/implementations/prometheus/queue.go
+++ b/implementations/prometheus/queue.go
@@ -29,7 +29,7 @@ var _ Queue = (*queue)(nil)
 //
 // Appender returns an Appender that writes to the queue.
 type Queue interface {
-	Start(ctx context.Context)
+	Start(ctx context.Context) error
 	Stop()
 	Appender(ctx context.Context) storage.Appender
 }
@@ -109,11 +109,15 @@ func NewQueue(name string, cc types.ConnectionConfig, directory string, maxSigna
 	return q, nil
 }
 
-func (q *queue) Start(ctx context.Context) {
+func (q *queue) Start(ctx context.Context) error {
 	q.network.Start(ctx)
 	q.queue.Start(ctx)
-	q.serializer.Start(ctx)
+	err := q.serializer.Start(ctx)
+	if err != nil {
+		return err
+	}
 	go q.run(ctx)
+	return nil
 }
 
 func (q *queue) Stop() {

--- a/serialization/appender.go
+++ b/serialization/appender.go
@@ -3,6 +3,7 @@ package serialization
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
@@ -14,12 +15,18 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+var metricPool = sync.Pool{
+	New: func() interface{} {
+		return &types.PrometheusMetric{}
+	},
+}
+
 type appender struct {
 	ctx            context.Context
 	ttl            time.Duration
 	s              types.PrometheusSerializer
 	logger         log.Logger
-	incrementTTL   func()
+	metrics        []*types.PrometheusMetric
 	externalLabels map[string]string
 }
 
@@ -32,6 +39,7 @@ func NewAppender(ctx context.Context, ttl time.Duration, s types.PrometheusSeria
 		logger:         logger,
 		ctx:            ctx,
 		externalLabels: externalLabels,
+		metrics:        make([]*types.PrometheusMetric, 0),
 	}
 	return app
 }
@@ -47,18 +55,35 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 	if t < endTime {
 		return ref, nil
 	}
-	err := a.s.SendMetric(a.ctx, l, t, v, nil, nil, a.externalLabels)
-	return ref, err
+	pm := metricPool.Get().(*types.PrometheusMetric)
+	pm.L = l
+	pm.T = t
+	pm.V = v
+	a.metrics = append(a.metrics, pm)
+	return ref, nil
 }
 
 // Commit is a no op since we always write.
-func (a *appender) Commit() (_ error) {
-	return nil
+func (a *appender) Commit() error {
+	defer putMetrics(a.metrics)
+	return a.s.SendMetrics(a.ctx, a.metrics, a.externalLabels)
 }
 
 // Rollback is a no op since we write all the data.
 func (a *appender) Rollback() error {
+	defer putMetrics(a.metrics)
 	return nil
+}
+
+func putMetrics(metrics []*types.PrometheusMetric) {
+	for _, m := range metrics {
+		m.FH = nil
+		m.H = nil
+		m.L = nil
+		m.T = 0
+		m.V = 0
+		metricPool.Put(m)
+	}
 }
 
 // AppendExemplar appends exemplar to cache. The passed in labels is unused, instead use the labels on the exemplar.
@@ -73,8 +98,13 @@ func (a *appender) AppendHistogram(ref storage.SeriesRef, l labels.Labels, t int
 	if t < endTime {
 		return ref, nil
 	}
-	err := a.s.SendMetric(a.ctx, l, t, 0, h, fh, a.externalLabels)
-	return ref, err
+	pm := metricPool.Get().(*types.PrometheusMetric)
+	pm.L = l
+	pm.T = t
+	pm.H = h
+	pm.FH = fh
+	a.metrics = append(a.metrics, pm)
+	return ref, nil
 }
 
 // UpdateMetadata updates metadata.

--- a/serialization/appender.go
+++ b/serialization/appender.go
@@ -63,13 +63,11 @@ func (a *appender) Append(ref storage.SeriesRef, l labels.Labels, t int64, v flo
 	return ref, nil
 }
 
-// Commit is a no op since we always write.
 func (a *appender) Commit() error {
 	defer putMetrics(a.metrics)
 	return a.s.SendMetrics(a.ctx, a.metrics, a.externalLabels)
 }
 
-// Rollback is a no op since we write all the data.
 func (a *appender) Rollback() error {
 	defer putMetrics(a.metrics)
 	return nil

--- a/serialization/serializer_test.go
+++ b/serialization/serializer_test.go
@@ -46,7 +46,13 @@ func TestRoundTripSerialization(t *testing.T) {
 				Value: fmt.Sprintf("value_%d_%d", i, j),
 			}
 		}
-		sendErr := s.SendMetric(context.Background(), lbls, time.Now().UnixMilli(), rand.Float64(), nil, nil, nil)
+		sendErr := s.SendMetrics(context.Background(), []*types.PrometheusMetric{
+			{
+				L: lbls,
+				T: time.Now().UnixMilli(),
+				V: rand.Float64(),
+			},
+		}, nil)
 		require.NoError(t, sendErr)
 	}
 	require.Eventually(t, func() bool {

--- a/types/metric.go
+++ b/types/metric.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"github.com/prometheus/prometheus/model/histogram"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
 type FileFormat string
 
 const AlloyFileVersionV1 = FileFormat("alloy.metrics.queue.v1")
@@ -33,4 +38,12 @@ type MetricDatum interface {
 type MetadataDatum interface {
 	Datum
 	IsMeta() bool
+}
+
+type PrometheusMetric struct {
+	L  labels.Labels
+	T  int64
+	V  float64
+	H  *histogram.Histogram
+	FH *histogram.FloatHistogram
 }

--- a/types/serializer.go
+++ b/types/serializer.go
@@ -2,8 +2,6 @@ package types
 
 import (
 	"context"
-	"github.com/prometheus/prometheus/model/histogram"
-	"github.com/prometheus/prometheus/model/labels"
 	"time"
 )
 
@@ -23,6 +21,6 @@ type Serializer interface {
 
 type PrometheusSerializer interface {
 	Serializer
-	SendMetric(ctx context.Context, l labels.Labels, t int64, v float64, h *histogram.Histogram, fh *histogram.FloatHistogram, externalLabels map[string]string) error
+	SendMetrics(ctx context.Context, metrics []*PrometheusMetric, externalLabels map[string]string) error
 	SendMetadata(ctx context.Context, name string, unit string, help string, pType string) error
 }


### PR DESCRIPTION
In large clusters high contention on the lock in serializer was noted, this should alleviate that pressure.