### PR TITLE
Properly iterate over externalLabels

### DIFF
--- a/serialization/appender.go
+++ b/serialization/appender.go
@@ -25,7 +25,7 @@ type appender struct {
 	ctx            context.Context
 	s              types.PrometheusSerializer
 	logger         log.Logger
-	externalLabels map[string]string
+	externalLabels labels.Labels
 	metrics        map[uint64]*types.PrometheusMetric
 	ttl            time.Duration
 	appendOptions  *storage.AppendOptions
@@ -33,7 +33,7 @@ type appender struct {
 
 // NewAppender returns an Appender that writes to a given serializer. NOTE the returned Appender writes
 // data immediately, discards data older than `ttl` and does not honor commit or rollback.
-func NewAppender(ctx context.Context, ttl time.Duration, s types.PrometheusSerializer, externalLabels map[string]string, logger log.Logger) storage.Appender {
+func NewAppender(ctx context.Context, ttl time.Duration, s types.PrometheusSerializer, externalLabels labels.Labels, logger log.Logger) storage.Appender {
 	app := &appender{
 		ttl:            ttl,
 		s:              s,

--- a/serialization/serializer.go
+++ b/serialization/serializer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/walqueue/types"
 	v2 "github.com/grafana/walqueue/types/v2"
 	"github.com/klauspost/compress/zstd"
+	"github.com/prometheus/prometheus/model/labels"
 	"go.uber.org/atomic"
 )
 
@@ -56,7 +57,7 @@ func NewSerializer(cfg types.SerializerConfig, q types.FileStorage, stats func(s
 
 // SendMetrics adds a slice metric to the serializer. Note that we need to inject external labels here since once they are written to disk the prompb.TimeSeries bytes should be treated
 // as immutable.
-func (s *serializer) SendMetrics(ctx context.Context, metrics []*types.PrometheusMetric, externalLabels map[string]string) error {
+func (s *serializer) SendMetrics(ctx context.Context, metrics []*types.PrometheusMetric, externalLabels labels.Labels) error {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 

--- a/types/marshaller.go
+++ b/types/marshaller.go
@@ -20,7 +20,7 @@ type PrometheusMarshaller interface {
 	Marshaller
 	// AddPrometheusMetric adds a metric to the list of metrics. External Labels are passed in and added to the raw byte representation.
 	// They are not added to lbls since that array may not be owned by the caller. Metric labels will override external labels.
-	AddPrometheusMetric(ts int64, value float64, lbls labels.Labels, h *histogram.Histogram, fh *histogram.FloatHistogram, e exemplar.Exemplar, externalLabels map[string]string) error
+	AddPrometheusMetric(ts int64, value float64, lbls labels.Labels, h *histogram.Histogram, fh *histogram.FloatHistogram, e exemplar.Exemplar, externalLabels labels.Labels) error
 	AddPrometheusMetadata(name string, unit string, help string, pType string) error
 }
 

--- a/types/serializer.go
+++ b/types/serializer.go
@@ -3,6 +3,8 @@ package types
 import (
 	"context"
 	"time"
+
+	"github.com/prometheus/prometheus/model/labels"
 )
 
 type SerializerConfig struct {
@@ -21,6 +23,6 @@ type Serializer interface {
 
 type PrometheusSerializer interface {
 	Serializer
-	SendMetrics(ctx context.Context, metrics []*PrometheusMetric, externalLabels map[string]string) error
+	SendMetrics(ctx context.Context, metrics []*PrometheusMetric, externalLabels labels.Labels) error
 	SendMetadata(ctx context.Context, name string, unit string, help string, pType string) error
 }

--- a/types/v1/serialization_func.go
+++ b/types/v1/serialization_func.go
@@ -36,7 +36,7 @@ func (s *Serialization) AddPrometheusMetadata(name string, unit string, help str
 	return nil
 }
 
-func (s *Serialization) AddPrometheusMetric(ts int64, value float64, lbls labels.Labels, h *histogram.Histogram, fh *histogram.FloatHistogram, _ exemplar.Exemplar, _ map[string]string) error {
+func (s *Serialization) AddPrometheusMetric(ts int64, value float64, lbls labels.Labels, h *histogram.Histogram, fh *histogram.FloatHistogram, _ exemplar.Exemplar, _ labels.Labels) error {
 	tss := s.createTimeSeries(ts, value, lbls, h, fh)
 	s.sg.Series = append(s.sg.Series, tss)
 	return nil

--- a/types/v2/format_test.go
+++ b/types/v2/format_test.go
@@ -68,19 +68,20 @@ func TestDeserializeAndSerialize(t *testing.T) {
 }
 
 func TestExternalLabels(t *testing.T) {
-	externalLabels := map[string]string{
-		"foo":     "bar",
-		"label_1": "bad_value",
+	externalLabels := []labels.Label{
+		{Name: "bar", Value: ""},
+		{Name: "foo", Value: "bar"},
+		{Name: "label_1", Value: "skipped"},
 	}
 	s := NewFormat()
 	lbls := make(labels.Labels, 0)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		lbls = append(lbls, labels.Label{
 			Name:  fmt.Sprintf("label_%d", i),
 			Value: randString(),
 		})
 	}
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		aErr := s.AddPrometheusMetric(time.Now().UnixMilli(), rand.Float64(), lbls, nil, nil, exemplar.Exemplar{}, externalLabels)
 		require.NoError(t, aErr)
 	}
@@ -102,13 +103,15 @@ func TestExternalLabels(t *testing.T) {
 			unErr := met.Unmarshal(ppb)
 			require.NoError(t, unErr)
 
-			require.Len(t, met.Labels, 11)
+			require.Len(t, met.Labels, 12)
 			for j, l := range lbls {
 				require.Equal(t, l.Name, met.Labels[j].Name)
 				require.Equal(t, l.Value, met.Labels[j].Value)
 			}
-			require.True(t, met.Labels[10].Name == "foo")
-			require.True(t, met.Labels[10].Value == "bar")
+			require.Equal(t, met.Labels[10].Name, "bar")
+			require.Equal(t, met.Labels[10].Value, "")
+			require.Equal(t, met.Labels[11].Name, "foo")
+			require.Equal(t, met.Labels[11].Value, "bar")
 		}
 	}
 }


### PR DESCRIPTION
Addressing this issue from Alloy: https://github.com/grafana/alloy/issues/4113

The root of the issue was that the lblIndex was not incremented when appending external labels. A side effect of that issue is that when re-using label slices, we were assuming we _would_ increment and add all external labels, leading to a leak of labels from previous data points. If the previous sample for the re-used series object had _more_ labels before the externals (or the externals iteration from map came back in a different order) then there would be potentially duplicate labels.