### PR TITLE
appender: Use a map for fast lookup and slice to maintain order

### DIFF
--- a/serialization/appender_test.go
+++ b/serialization/appender_test.go
@@ -1,0 +1,50 @@
+package serialization_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/walqueue/serialization"
+	"github.com/grafana/walqueue/types"
+)
+
+type testSender struct {
+	sent []types.PrometheusMetric
+}
+
+func (ts *testSender) SendMetrics(ctx context.Context, metrics []*types.PrometheusMetric, externalLabels labels.Labels) error {
+	for _, m := range metrics {
+		// Shallow copy since the appender is going to clear the incoming value
+		ts.sent = append(ts.sent, *m)
+	}
+	return nil
+}
+
+func (ts *testSender) SendMetadata(ctx context.Context, name string, unit string, help string, pType string) error {
+	panic("Not implemented")
+}
+
+func TestAppenderMaintainsAppendedOrder(t *testing.T) {
+	sender := &testSender{}
+	app := serialization.NewAppender(t.Context(), time.Hour, sender, nil, log.NewNopLogger())
+
+	for i := range 10 {
+		_, err := app.Append(storage.SeriesRef(i), labels.FromStrings(strconv.Itoa(i), "bar"), time.Now().UnixMilli(), float64(i))
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, app.Commit())
+	require.Len(t, sender.sent, 10)
+
+	for i := range 10 {
+		assert.Equal(t, strconv.Itoa(i), sender.sent[i].L[0].Name)
+	}
+}

--- a/types/serializer.go
+++ b/types/serializer.go
@@ -21,8 +21,12 @@ type Serializer interface {
 	UpdateConfig(ctx context.Context, cfg SerializerConfig) (bool, error)
 }
 
-type PrometheusSerializer interface {
-	Serializer
+type Sender interface {
 	SendMetrics(ctx context.Context, metrics []*PrometheusMetric, externalLabels labels.Labels) error
 	SendMetadata(ctx context.Context, name string, unit string, help string, pType string) error
+}
+
+type PrometheusSerializer interface {
+	Serializer
+	Sender
 }


### PR DESCRIPTION
We have found through tests that maintaining the append order for metrics improves compression rations ~30%. When comparing received payload sizes in a local setup

compared to upstream before
```
2025/09/10 18:05:50 [queue] Compressed size: 34419 bytes
2025/09/10 18:05:50 [queue] Uncompressed size: 180915 bytes
2025/09/10 18:05:51 [rw] Compressed size: 24054 bytes
2025/09/10 18:05:51 [rw] Uncompressed size: 180915 bytes
```

compared to upstream after
```
2025/09/11 12:05:23 [queue] Compressed size: 8725 bytes
2025/09/11 12:05:23 [queue] Uncompressed size: 71993 bytes
2025/09/11 12:05:23 [rw] Compressed size: 8725 bytes
2025/09/11 12:05:23 [rw] Uncompressed size: 71993 bytes
```

I was working on adding network info to the benchmark results so we can keep an eye on it but it's taken longer than I would like and will do it in a follow up. 