### PR TITLE
Remove duplicate Size calls from proto serialization

### DIFF
--- a/network/request.go
+++ b/network/request.go
@@ -6,9 +6,10 @@ import (
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/grafana/walqueue/types"
 	"github.com/prometheus/prometheus/prompb"
 	writev2 "github.com/prometheus/prometheus/prompb/io/prometheus/write/v2"
+
+	"github.com/grafana/walqueue/types"
 )
 
 // Used to deserialize the data from the WAL so we can construct the v2 request
@@ -89,11 +90,12 @@ func generateWriteRequestV2[T types.Datum](symbolTable *writev2.SymbolsTable, se
 		Timeseries: ts,
 	}
 
-	if len(input) < req.Size() {
-		input = make([]byte, req.Size())
+	reqSize := req.Size()
+	if len(input) < reqSize {
+		input = make([]byte, reqSize)
 	}
 
-	_, err := req.MarshalTo(input)
+	_, err := req.MarshalToSizedBuffer(input[:reqSize])
 	return input, err
 }
 

--- a/types/v2/format.go
+++ b/types/v2/format.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/grafana/walqueue/types"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
+
+	"github.com/grafana/walqueue/types"
 )
 
 // Format describe the v2 data format.
@@ -124,7 +125,7 @@ func (s *Format) AddPrometheusMetric(ts int64, value float64, lbls labels.Labels
 	} else {
 		s.seriesBuf = s.seriesBuf[:seriesSize]
 	}
-	_, err := s.series.MarshalTo(s.seriesBuf)
+	_, err := s.series.MarshalToSizedBuffer(s.seriesBuf[:seriesSize])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changes the way we handle sizing the slice for protobuf serialization to avoid duplicate calls to Size() which is not a free call. See CPU profiles,
<img width="957" height="154" alt="image" src="https://github.com/user-attachments/assets/5371e7ae-08bf-48ae-b379-b6ff32747063" />

The remote write v2 code had an explicit duplicate call and remote write v2 + serialization call it twice through `MarshalTo` which will call Size again to call a different marshal function ex,

```go
func (m *Request) MarshalTo(dAtA []byte) (int, error) {
	size := m.Size()
	return m.MarshalToSizedBuffer(dAtA[:size])
}
```

This pulls that forward so we can avoid duplicate calls to Size(). Bench results from the serializer,
```
                              │ baseline.txt │              new.txt              │
                              │    sec/op    │   sec/op     vs base              │
DeserializeAndSerialize/v2-11    5.891m ± 3%   5.387m ± 2%  -8.55% (p=0.002 n=6)

                              │ baseline.txt │               new.txt               │
                              │     B/op     │     B/op      vs base               │
DeserializeAndSerialize/v2-11   12.81Mi ± 0%   11.44Mi ± 0%  -10.68% (p=0.002 n=6)

                              │ baseline.txt │           new.txt            │
                              │  allocs/op   │  allocs/op   vs base         │
DeserializeAndSerialize/v2-11    10.06k ± 0%   10.06k ± 0%  ~ (p=0.554 n=6)

```