### PR TITLE
Change LRU implementation to one that is concurrency friendly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v1.0.0
-	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/klauspost/compress v1.18.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
@@ -21,6 +20,8 @@ require (
 	go.uber.org/atomic v1.11.0
 	golang.design/x/chann v0.1.2
 )
+
+require github.com/elastic/go-freelru v0.16.0
 
 require (
 	cloud.google.com/go/auth v0.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/elastic/go-freelru v0.16.0 h1:gG2HJ1WXN2tNl5/p40JS/l59HjvjRhjyAa+oFTRArYs=
+github.com/elastic/go-freelru v0.16.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.13.4 h1:zEqyPVyku6IvWCFwux4x9RxkLOMUL+1vC9xUFv5l2/M=
@@ -142,8 +144,6 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
 github.com/hashicorp/golang-lru v0.6.0/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
-github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/nomad/api v0.0.0-20241218080744-e3ac00f30eec h1:+YBzb977VrmffaCX/OBm17dEVJUcWn5dW+eqs3aIJ/A=
 github.com/hashicorp/nomad/api v0.0.0-20241218080744-e3ac00f30eec/go.mod h1:svtxn6QnrQ69P23VvIWMR34tg3vmwLz4UdUzm1dSCgE=
 github.com/hashicorp/serf v0.10.1 h1:Z1H2J60yRKvfDYAOZLd2MU0ND4AH/WDz7xYHDWQsIPY=

--- a/network/metadata_cache_benchmark_test.go
+++ b/network/metadata_cache_benchmark_test.go
@@ -1,0 +1,92 @@
+package network
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/walqueue/types"
+	v2 "github.com/grafana/walqueue/types/v2"
+	"github.com/prometheus/prometheus/prompb"
+	"go.uber.org/atomic"
+)
+
+// BenchmarkMetadataCacheConcurrency benchmarks cache under high concurrency
+func BenchmarkMetadataCacheConcurrency(b *testing.B) {
+	concurrencyLevels := []int{1, 10, 50, 100, 500, 1000}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("goroutines_%d", concurrency), func(b *testing.B) {
+			benchmarkMetadataCacheConcurrency(b, concurrency)
+		})
+	}
+}
+
+func benchmarkMetadataCacheConcurrency(b *testing.B, goroutines int) {
+	metricNames := make([]string, 10000)
+	for i := range metricNames {
+		metricNames[i] = fmt.Sprintf("metric_%d", i)
+	}
+	testMetadata := make([]types.MetadataDatum, 10000)
+	for i := range testMetadata {
+		testMetadata[i] = createTestMetadata(metricNames[i])
+	}
+
+	cache, err := NewMetadataCache(1000)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Pre-populate cache
+	for i := range 1000 {
+		cache.Set(testMetadata[i])
+	}
+
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	doneWriting := atomic.NewBool(false)
+	// One goroutine should be adding metadata continuously
+	go func() {
+		r := rand.New(rand.NewSource(time.Now().UnixMilli()))
+		for doneWriting.Load() == false {
+			cache.Set(testMetadata[r.Intn(10000)])
+		}
+	}()
+
+	// N worker goroutines performing read operations
+	for i := range goroutines {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(workerID)))
+
+			for range b.N {
+				// Read operation
+				cache.GetIfNotSent(metricNames[r.Intn(10000)])
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	doneWriting.Store(true)
+}
+
+// Helper functions
+func createTestMetadata(metricName string) types.MetadataDatum {
+	metadata := &prompb.MetricMetadata{
+		MetricFamilyName: metricName,
+		Type:             prompb.MetricMetadata_COUNTER,
+		Help:             fmt.Sprintf("Help text for %s", metricName),
+		Unit:             "seconds",
+	}
+
+	data, _ := metadata.Marshal()
+	return v2.Metadata{
+		Buf: data,
+	}
+}
+
+//BenchmarkMetadataCacheConcurrency/goroutines_1000-12      	    7998	    126622 ns/op	     767 B/op	       2 allocs/op


### PR DESCRIPTION


I had a WIP benchmark, but it wasn't quite measuring what I wanted it to...
```
package network

import (
	"fmt"
	"math/rand"
	"sync"
	"testing"
	"time"

	"github.com/grafana/walqueue/types"
	v2 "github.com/grafana/walqueue/types/v2"
	"github.com/prometheus/prometheus/prompb"
	"go.uber.org/atomic"
)

// BenchmarkMetadataCacheConcurrency benchmarks cache under high concurrency
func BenchmarkMetadataCacheConcurrency(b *testing.B) {
	concurrencyLevels := []int{1, 10, 50, 100, 500, 1000}

	for _, concurrency := range concurrencyLevels {
		b.Run(fmt.Sprintf("goroutines_%d", concurrency), func(b *testing.B) {
			benchmarkMetadataCacheConcurrency(b, concurrency)
		})
	}
}

func benchmarkMetadataCacheConcurrency(b *testing.B, goroutines int) {
	metricNames := make([]string, 10000)
	for i := range metricNames {
		metricNames[i] = fmt.Sprintf("metric_%d", i)
	}
	testMetadata := make([]types.MetadataDatum, 10000)
	for i := range testMetadata {
		testMetadata[i] = createTestMetadata(metricNames[i])
	}

	cache, err := NewMetadataCache(1000)
	if err != nil {
		b.Fatal(err)
	}

	// Pre-populate cache
	for i := range 1000 {
		cache.Set(testMetadata[i])
	}

	b.ResetTimer()

	var wg sync.WaitGroup
	doneWriting := atomic.NewBool(false)
	// One goroutine should be adding metadata continuously
	go func() {
		r := rand.New(rand.NewSource(time.Now().UnixMilli()))
		for doneWriting.Load() == false {
			cache.Set(testMetadata[r.Intn(10000)])
		}
	}()

	// N worker goroutines performing read operations
	for i := range goroutines {
		wg.Add(1)
		go func(workerID int) {
			defer wg.Done()
			r := rand.New(rand.NewSource(int64(workerID)))

			for range b.N {
				// Read operation
				cache.GetIfNotSent(metricNames[r.Intn(10000)])
			}
		}(i)
	}

	wg.Wait()
	doneWriting.Store(true)
}

// Helper functions
func createTestMetadata(metricName string) types.MetadataDatum {
	metadata := &prompb.MetricMetadata{
		MetricFamilyName: metricName,
		Type:             prompb.MetricMetadata_COUNTER,
		Help:             fmt.Sprintf("Help text for %s", metricName),
		Unit:             "seconds",
	}

	data, _ := metadata.Marshal()
	return v2.Metadata{
		Buf: data,
	}
}

// old LRU
// BenchmarkMetadataCacheConcurrency/goroutines_1000-12      	    7998	    126622 ns/op	     767 B/op	       2 allocs/op
// new LRU
// BenchmarkMetadataCacheConcurrency/goroutines_1000-12      	   17666	     68201 ns/op	     423 B/op	       4 allocs/op

```